### PR TITLE
Fix: resolve crash when visiting the "contact" page

### DIFF
--- a/src/pages/Contact/ContactInfo/ContactInfo.jsx
+++ b/src/pages/Contact/ContactInfo/ContactInfo.jsx
@@ -40,7 +40,9 @@ const ContactInfo = function () {
 				</div>
 				<div className="contact-info__list-item">
 					<dt className="contact-info__term">Telephone</dt>
-					<dd className="contact-info__details">{formatPhoneNumber(content.contactNumber)}</dd>
+					<dd className="contact-info__details">
+						{content.contactNumber && formatPhoneNumber(content.contactNumber)}
+					</dd>
 				</div>
 				<div className="contact-info__list-item">
 					<dt className="contact-info__term">Address</dt>


### PR DESCRIPTION
- Check for the existence of `contactNumber` before invoking `formatPhoneNumber()` on it.
- Resolves #10